### PR TITLE
Update artifact github actions to v4

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./wheelhouse/*.whl
@@ -103,7 +103,7 @@ jobs:
     needs: [build_wheels]
 
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: wheels
           path: dist


### PR DESCRIPTION
Resolves #15 

(Noted too that the submodules of mitsuba3 will also require this update, although none of those are forked into our organisation, so there's no need for us to do anything about them immediately).