### PR TITLE
First pass at rewriting photon emitters into a single cpp file

### DIFF
--- a/MPhys/Single_Emitter/single_emitter_test_new_single_test.py
+++ b/MPhys/Single_Emitter/single_emitter_test_new_single_test.py
@@ -1,0 +1,287 @@
+import drjit as dr
+import mitsuba as mi
+import time
+import pandas as pd
+import numpy as np
+import random
+
+
+# mi.set_variant('cuda_mono')
+mi.set_variant('llvm_mono')
+mi.variants()
+# dr.set_log_level(dr.LogLevel.Info)
+mi.set_log_level(mi.LogLevel.Info)
+
+nm_per_ev_constant = (float(6.6260715e-34)*float(3.00e8)*float(1e9))/(float(1.6021e-19)*float(1e6))
+
+# Load in the CSV file
+# column_names = ["time (ps)", "x", "y", "z", "px", "py", "pz", "E (MeV)"]
+# The first column in the CSV file is an index column and we don't want to load that in
+photon_detected = pd.read_csv('csv/test_new_photons_detected_spectral.csv', index_col=0) #, names = column_names)
+print(photon_detected)
+
+def generate_emitter_data(photon_data):
+    """
+    Generates the data for the photon_emitter plugin of Mitsuba using the photon data
+    """
+    x_position, y_position, z_position = photon_data.values[:, 1:4].T
+    x_momentum, y_momentum, z_momentum = photon_data.values[:, 4:7].T
+    # calculate the target coordinates of the photons
+    x_target = x_position + x_momentum
+    y_target = y_position + y_momentum
+    z_target = z_position + z_momentum
+    # combine them into a single array
+    # emitter_data = np.column_stack((x_position, y_position, z_position, x_target, y_target, z_target)).flatten()
+    # The y- and z- positions in other examples were inverted for some reason... ?
+    emitter_data = np.column_stack((x_position, z_position, y_position, x_target, z_target, y_target)).flatten()
+    emitter_data = np.insert(emitter_data, 0, len(x_position))
+    # create a 3D array of the emitter data
+    result = np.zeros((1, 1, len(emitter_data)), dtype=np.float32)
+    result[0, 0, :] = emitter_data
+    return result
+
+# gen_photon_datas = []
+photon_lists = []
+
+# Loop to generate photon data from the photon_detected data frame
+
+gen_photon_data = generate_emitter_data(photon_detected)
+photon_list = mi.VolumeGrid(gen_photon_data)
+photon_lists.append(photon_list)
+
+print("--------------------------------")
+print (photon_list)
+print (np.array(photon_list))
+print (gen_photon_data)
+
+print ("n_photons into mitsuba ", (len(np.array(photon_list)[0][0]) - 1) // 6)
+
+start_time = time.time()
+
+intensity = 2000000.0
+
+# Set up the scene description
+scene_description = {
+    'type': 'scene',
+
+    'integrator': {
+        'type': 'ptracer_c',  # ptracer?
+        'max_depth': 50,
+        'hide_emitters': False,
+    },
+
+    'sensor': {
+        'type': 'perspective',
+        'fov': 40,
+        'to_world': mi.ScalarTransform4f().look_at(origin=[0, 1100, 950],
+                                                 target=[0, 1500, 1500],
+                                                 up=[0, 0, 1]),
+        'sampler': {
+            'type': 'independent',
+            'sample_count': 1,
+        },
+        'film': {
+            'type': 'hdrfilm',
+            'width': 1024,
+            'height': 1024,
+            'file_format': 'openexr',
+            'pixel_format': 'luminance',
+            'component_format': 'float32',
+            'filter': {
+                'type': 'tent',
+            },
+        },      
+    },
+
+    'MirrorBSDF': {
+        'type': 'twosided',
+        'bsdf_id': {
+            'type': 'conductor',
+            'material': 'none',
+        },
+    },
+
+    # 'RoughMirrorBSDF': {
+    #     'type': 'conductor',
+    #     'material': 'none',
+    #     'alpha': 0.01,
+    # },
+
+    'test': {
+        'type': 'twosided',
+        'bsdf_id': {
+            'type': 'diffuse',
+            'reflectance': {
+                'type': 'rgb',
+                'value': [1, 1, 1],
+            },
+        },
+    },
+
+    'test2': {
+        'type': 'twosided',
+        'bsdf_id': {
+            'type': 'diffuse',
+            'reflectance': {
+                'type': 'rgb',
+                'value': [0.9, 0.5, 0.2],
+            },
+        },
+    },
+
+    'spherical_mirror': {
+        'type': 'cube',
+        'to_world': mi.ScalarTransform4f().look_at(
+            origin=[0, 2000, 355], target=[0, 1000, 600], up=[0, 0, 1]).scale([1500, 650, 33]),
+        'bsdf_id': {
+            'type': 'ref',
+            'id': 'MirrorBSDF',
+        },
+    },
+
+    'flat_mirror': {
+        'type': 'rectangle',
+        'to_world': mi.ScalarTransform4f().look_at(
+            origin=[0, 1000, 710], target=[0, 2000, 900], up=[0, 0, 1]).scale([740, 440, 0.1]),
+        'bsdf_id': {
+            'type': 'ref',
+            'id': 'MirrorBSDF',
+        },
+    },
+
+    'detector': {
+        'type': 'rectangle',
+        'to_world': mi.ScalarTransform4f().look_at(
+            origin=[0, 1500, 1120], target=[0, 1000, 710], up=[0, 0, 1]).scale([1000, 500, 0.5]),
+        'bsdf_id': {
+            'type': 'ref',
+            'id': 'test',
+        },        
+    },
+
+    'backwall': {
+        'type': 'rectangle',
+        'to_world': mi.ScalarTransform4f().look_at(
+            origin=[-1000, 1500, 500], target=[0, 1500, 500], up=[0, 1, 0]).scale([3000, 3000, 1]),
+        'bsdf_id': {
+            'type': 'diffuse',
+            'reflectance': {
+                'type': 'rgb',
+                'value': [0.4, 1, 0.2],
+            },
+        },        
+    },
+        
+    'ceiling': {
+        'type': 'rectangle',
+        'to_world': mi.ScalarTransform4f().look_at(
+            origin=[0, 1500, 3000], target=[0, 1500, 0], up=[0, 1, 0]).scale([3000, 3000, 1]),
+        'bsdf_id': {
+            'type': 'diffuse',
+            'reflectance': {
+                'type': 'rgb',
+                'value': [0.8, 0.3, 0.45],
+            },
+        },        
+    },
+        
+    'leftwall': {
+        'type': 'rectangle',
+        'to_world': mi.ScalarTransform4f().look_at(
+            origin=[0, 0, 500], target=[0, 1500, 500], up=[0, 0, 1]).scale([3000, 3000, 3000]),
+        'bsdf_id': {
+            'type': 'diffuse',
+            'reflectance': {
+                'type': 'rgb',
+                'value': [0.32, 0.46, 0.23],
+            },
+        },        
+    },
+        
+    'rightwall': {
+        'type': 'rectangle',
+        'to_world': mi.ScalarTransform4f().look_at(
+            origin=[0, 3000, 500], target=[0, 1500, 500], up=[0, 0, 1]).scale([3000, 3000, 3000]),
+        'bsdf_id': {
+            'type': 'diffuse',
+            'reflectance': {
+                'type': 'rgb',
+                'value': [0.92, 0.58, 1],
+            },
+        },        
+    },
+
+    'floor': {
+        'type': 'rectangle',
+        'to_world': mi.ScalarTransform4f().look_at(
+            origin=[0, 1500, -1000], target=[0, 1500, 3000], up=[0, 1, 0]).scale([3000, 3000, 3000]),
+        'bsdf_id': {
+            'type': 'diffuse',
+            'reflectance': {
+                'type': 'rgb',
+                'value': [0.56, 0.23, 0.54],
+            },
+        },        
+    },
+
+    'photons': {
+        'type': 'photon_emitter',
+        'photon_list': photon_list,
+        'filename': 'bintxt/photon_geometry.bin',
+        'intensity': intensity,
+    },        
+}
+
+# Load from dict or from XML file
+print("================== load_dict ==================")
+scene = mi.load_dict(scene_description)
+# print("================== load_file ==================")
+# scene = mi.load_file("./xml/real_geometry_int"+str(int(intensity))+".xml")
+# print(scene)
+
+print("================== render =====================")
+original_image = mi.render(scene)
+# print(original_image)
+import matplotlib.pyplot as plt
+import matplotlib
+# Use agg backend for matplotlib since we're just writing to files
+# Note: in WSL2 with python3-tk installed, allowing matplotlib to select automatically
+#       (I assume it picks 'TkAgg' in this instance) causes a segmentation fault!
+matplotlib.use('agg')
+
+plt.figure(figsize = (20,20))
+plt.axis('off')
+plt.imshow(original_image ** (1.0 / 2.2)); 
+end_time = time.time()
+elapsed_time = end_time - start_time
+print(f"Elapsed time: {elapsed_time:.2f} seconds")
+print("new intensity = ", int(intensity))
+plt.savefig('png/new intensity = ' + str(int(intensity)))
+
+def compare_images(old_fname, new_fname):
+    old_image = plt.imread(old_fname)
+    new_image = plt.imread(new_fname)
+    diff_image = old_image - new_image
+
+    print(type(diff_image))
+    print(np.max(diff_image), np.min(diff_image))
+    print(diff_image.shape)
+    
+    fig, (ax1, ax2, ax3) = plt.subplots(3)
+    fig.set_figheight(30)
+    fig.set_figwidth(10)
+    ax1.set_title('original image (from loaded XML) ' + old_fname)
+    ax1.imshow(old_image)
+    ax2.set_title('new image (from loaded vector via dict) ' + new_fname)
+    ax2.imshow(new_image)
+    ax3.set_title('difference image')
+    ax3.imshow(diff_image - np.min(diff_image))
+    
+    print("diff image")
+    plt.savefig('png/diff image' + old_fname[4:-4])
+
+# Compare this image to the previous one
+old_fname = 'png/intensity = '+str(int(intensity))+'.png'
+new_fname = 'png/new intensity = '+str(int(intensity))+'.png'
+
+compare_images(old_fname, new_fname)

--- a/MPhys/Single_Emitter/single_emitter_test_new_single_test.py
+++ b/MPhys/Single_Emitter/single_emitter_test_new_single_test.py
@@ -17,7 +17,7 @@ nm_per_ev_constant = (float(6.6260715e-34)*float(3.00e8)*float(1e9))/(float(1.60
 # Load in the CSV file
 # column_names = ["time (ps)", "x", "y", "z", "px", "py", "pz", "E (MeV)"]
 # The first column in the CSV file is an index column and we don't want to load that in
-photon_detected = pd.read_csv('csv/test_new_photons_detected_spectral.csv', index_col=0) #, names = column_names)
+photon_detected = pd.read_csv('csv/photons_detected_spectral.csv', index_col=0) #, names = column_names)
 print(photon_detected)
 
 def generate_emitter_data(photon_data):
@@ -264,7 +264,12 @@ def compare_images(old_fname, new_fname):
     diff_image = old_image - new_image
 
     print(type(diff_image))
-    print(np.max(diff_image), np.min(diff_image))
+    print("Max/min in old image ", np.max(old_image), np.min(old_image))
+    print("Max/min in new image ", np.max(new_image), np.min(new_image))
+    print("Max/min in diff image ", np.max(diff_image), np.min(diff_image))
+    print("Average/median in diff image ", np.average(diff_image), np.median(diff_image))
+    print("Average/median of non-zero diffs ", np.average(diff_image[np.nonzero(diff_image)]),
+          np.median(diff_image[np.nonzero(diff_image)]))
     print(diff_image.shape)
     
     fig, (ax1, ax2, ax3) = plt.subplots(3)

--- a/MPhys/Single_Emitter/xml/real_geometry_int1000.xml
+++ b/MPhys/Single_Emitter/xml/real_geometry_int1000.xml
@@ -133,7 +133,7 @@
             <rgb name="reflectance" value="0.56, 0.23, 0.54" />
         </bsdf>
 	</shape>
-    <emitter type="photon_emitter_old" id="pE1">
+    <emitter type="photon_emitter" id="pE1">
 		<string name="filename" value="bintxt/photon_geometry.bin"/>
         <rgb name="intensity" value="1000.0"/>
     </emitter>

--- a/MPhys/Single_Emitter/xml/real_geometry_int2000000.xml
+++ b/MPhys/Single_Emitter/xml/real_geometry_int2000000.xml
@@ -133,7 +133,7 @@
             <rgb name="reflectance" value="0.56, 0.23, 0.54" />
         </bsdf>
 	</shape>
-    <emitter type="photon_emitter_old" id="pE1">
+    <emitter type="photon_emitter" id="pE1">
 		<string name="filename" value="bintxt/photon_geometry.bin"/>
         <rgb name="intensity" value="2000000.0"/>
     </emitter>

--- a/src/emitters/photon_emitter.cpp
+++ b/src/emitters/photon_emitter.cpp
@@ -92,14 +92,16 @@ public:
         m_flags = +EmitterFlags::DeltaPosition;
         m_intensity = props.texture_d65<Texture>("intensity", 1.f);
 
-        // Declare Float arrays for origin and target coordinates
+        // Declare arrays for origin and target coordinates
         Float float_origin_x, float_origin_y, float_origin_z, float_target_x, float_target_y, float_target_z;
+        std::vector<float> origin_x, origin_y, origin_z, target_x, target_y, target_z;
+        int count;
 
         // If a photon_list property exists then load as a VolumeGrid code object
         if (props.has_property("photon_list")) {
-            // Log(Info, "photon emitter reading from code object (VolumeGrid)");
             // If filename has also been specified then ignore it
             if (props.has_property("filename")) {
+                // If filename has been specified it needs to be resolved otherwise there will be a RuntimeError
                 FileResolver *fs = Thread::thread()->file_resolver();
                 fs::path file_path = fs->resolve(props.string("filename"));
                 Log(Info, "The parameters 'filename' and 'photon_list' were both specified; ignoring 'filename'.");
@@ -108,9 +110,8 @@ public:
             ref<Object> other = props.object("photon_list");
             VolumeGrid *volume_grid = dynamic_cast<VolumeGrid *>(other.get());
             float *ptr = volume_grid->data();
-            int count = ptr[0];
+            count = ptr[0];
             int counter = 0.;
-            std::vector<float> origin_x, origin_y, origin_z, target_x, target_y, target_z;
             while (counter != count) {
                 float x = ptr[1+counter*6];
                 float y = ptr[2+counter*6];
@@ -129,13 +130,6 @@ public:
                 target_z.push_back(c);
                 counter ++;
             }
-            // Load them each into separate Float variables
-            float_origin_x = dr::load<Float>(origin_x.data(), count);
-            float_origin_y = dr::load<Float>(origin_y.data(), count);
-            float_origin_z = dr::load<Float>(origin_z.data(), count);
-            float_target_x = dr::load<Float>(target_x.data(), count);
-            float_target_y = dr::load<Float>(target_y.data(), count);
-            float_target_z = dr::load<Float>(target_z.data(), count);
         // Otherwise look for a filename property and load that
         } else if (props.has_property("filename")) {
             // Read the file
@@ -146,12 +140,12 @@ public:
             binaryStream -> set_byte_order(Stream::ELittleEndian);
 
             // The first line of the file shows the number of the photons
-            size_t count;
-            binaryStream->read(&count, sizeof(size_t));
+            size_t count_size;
+            binaryStream->read(&count_size, sizeof(size_t));
+            count = int(count_size);
             // std::cout << "The number of photons is: " << count << std::endl;
             size_t counter = 0.;
-            std::vector<float> origin_x, origin_y, origin_z, target_x, target_y, target_z;
-            while (counter != count) {
+            while (counter != count_size) {
                 // Declare three float variables
                 float x,y,z;
                 binaryStream->read(&x, sizeof(float));
@@ -171,16 +165,17 @@ public:
                 counter ++;
             }
             binaryStream->close();
-            // Load them each into separate Float variables
-            float_origin_x = dr::load<Float>(origin_x.data(), count);
-            float_origin_y = dr::load<Float>(origin_y.data(), count);
-            float_origin_z = dr::load<Float>(origin_z.data(), count);
-            float_target_x = dr::load<Float>(target_x.data(), count);
-            float_target_y = dr::load<Float>(target_y.data(), count);
-            float_target_z = dr::load<Float>(target_z.data(), count);
         } else {
             Throw("A photon emitter requires one of 'photon_list' (VolumeGrid code object) or 'filename' (binary file) to be specified.");
         }
+
+        // Load them each into separate Float variables
+        float_origin_x = dr::load<Float>(origin_x.data(), count);
+        float_origin_y = dr::load<Float>(origin_y.data(), count);
+        float_origin_z = dr::load<Float>(origin_z.data(), count);
+        float_target_x = dr::load<Float>(target_x.data(), count);
+        float_target_y = dr::load<Float>(target_y.data(), count);
+        float_target_z = dr::load<Float>(target_z.data(), count);
 
         // Create two Point3f and one Vector3f for origins, targets and ups from these Float variables
         Point3f origin(float_origin_x, float_origin_y, float_origin_z);

--- a/src/emitters/photon_emitter.cpp
+++ b/src/emitters/photon_emitter.cpp
@@ -1,3 +1,6 @@
+// TODO: check which of these includes are needed
+//       (This is effectively a "simplified" version of spot.cpp
+//        so it shouldnt need all the extra headers?)
 #include <mitsuba/core/properties.h>
 #include <mitsuba/core/warp.h>
 #include <mitsuba/core/plugin.h>
@@ -187,21 +190,9 @@ public:
 
         if (m_intensity->is_spatially_varying())
             Throw("The parameter 'intensity' cannot be spatially varying (e.g. bitmap type)!");
-        // dr::set_attr(this, "flags", m_flags);
-        // degree to radiance: degree * pi / 180
-        // TODO: do these need to be parameters for this emitter, or are they
-        ///      covered by the information in the photon list that's been loaded in?
-        m_cutoff_angle = dr::deg_to_rad(0.01f);
-        m_beam_width   = dr::deg_to_rad(0.01f*3.0f / 4.0f);
-        // if the m_cutoff_angle is equal to m_beam_width, the denominator will be 0, it's impossible!
-        m_inv_transition_width = 1.0f / (m_cutoff_angle - m_beam_width);
-        m_cos_cutoff_angle = dr::cos(m_cutoff_angle);
-        m_cos_beam_width   = dr::cos(m_beam_width);
-        Assert(dr::all(m_cutoff_angle >= m_beam_width));
+
         // Avoid baking
-        dr::make_opaque(m_beam_width, m_cutoff_angle,
-                        m_cos_beam_width, m_cos_cutoff_angle,
-                        m_inv_transition_width, m_transforms);
+        dr::make_opaque(m_transforms);
     }
 
     std::pair<Ray3f, Spectrum> sample_ray(Float time, Float wavelength_sample,
@@ -210,7 +201,6 @@ public:
                                           Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::EndpointSampleRay, active);
         // 1. Sample directional component
-        // TODO: again this is a single direction? Should it be allowed to be multiple?
         ScalarVector3f local_dir =  ScalarVector3f(0.f, 0.f, 1.f);
         Float pdf_dir = 445029;
         // Uniformly sample the light rays
@@ -224,11 +214,11 @@ public:
         auto si = dr::zeros<SurfaceInteraction3f>();
         si.time = time;
         si.p    = Transform4f(transforms).translation();
-        si.uv   = Point2f(0.5,0.5);
+        si.uv   = Point2f(0.5f,0.5f);
         // generate a set of random wavelengths and the corresponding spectral weight
         auto [wavelengths, spec_weight] =
             sample_wavelengths(si, wavelength_sample, active);
-        // TODO: calculate falloff using falloff_curve ?
+        // TODO: rename this to something other than "falloff"
         Float falloff = 1.0f;
         Ray3f result = Ray3f(si.p, new_dir, time, wavelengths);
         return {result, depolarizer<Spectrum>(spec_weight * falloff / pdf_dir)};
@@ -242,7 +232,6 @@ public:
         Matrix4f transforms = dr::gather<Matrix4f>(m_transforms, index);
         DirectionSample3f ds;
         ds.p        = Transform4f(transforms).translation();
-        // ds.p        = m_to_world.value().translation();
         ds.n        = 0.f;
         ds.uv       = 0.f;
         ds.pdf      = 1.f;
@@ -253,7 +242,7 @@ public:
         ds.dist     = dr::norm(ds.d);
         Float inv_dist = dr::rcp(ds.dist);
         ds.d        *= inv_dist;
-        // Vector3f local_d = m_to_world.value().inverse() * -ds.d;
+        // TODO: rename this to something other than "falloff"
         Float falloff = 1.0f;
         active &= falloff > 0.f;  // Avoid invalid texture lookups
 
@@ -310,9 +299,6 @@ public:
         oss << "PhotonEmitter[" << std::endl
             << "  to_world = " << string::indent(m_to_world) << "," << std::endl
             << "  intensity = " << m_intensity << "," << std::endl
-            // TODO: cutoff_angle isn't a parameter, so should it be here?
-            << "  cutoff_angle = " << m_cutoff_angle << "," << std::endl
-            << "  beam_width = " << m_beam_width << "," << std::endl
             << "  medium = " << (m_medium ? string::indent(m_medium) : "")
             << "]";
         return oss.str();
@@ -323,8 +309,6 @@ private:
     Matrix4f m_transforms;
     std::string m_filename;
     ref<Texture> m_intensity;
-    Float m_beam_width, m_cutoff_angle;
-    Float m_cos_beam_width, m_cos_cutoff_angle, m_inv_transition_width;
 };
 
 

--- a/src/emitters/photon_emitter.cpp
+++ b/src/emitters/photon_emitter.cpp
@@ -32,72 +32,96 @@ public:
         m_flags = +EmitterFlags::DeltaPosition;
         m_intensity = props.texture_d65<Texture>("intensity", 1.f);
 
-        ref<Object> other = props.object("photon_list");
-        VolumeGrid *volume_grid = dynamic_cast<VolumeGrid *>(other.get());
-        float *ptr = volume_grid->data();
-        int count= ptr[0];
-        int counter = 0.;
-        std::vector<float> origin_x, origin_y, origin_z, target_x, target_y, target_z;
-        while (counter != count) {
-            float x = ptr[1+counter*6];
-            float y = ptr[2+counter*6];
-            float z = ptr[3+counter*6];
+        // Declare Float arrays for origin and target coordinates
+        Float float_origin_x, float_origin_y, float_origin_z, float_target_x, float_target_y, float_target_z;
 
-            origin_x.push_back(x);
-            origin_y.push_back(y);
-            origin_z.push_back(z);
-            // Declare three float variables
-            float a = ptr[4+counter*6];
-            float b = ptr[5+counter*6];
-            float c = ptr[6+counter*6];
+        // If a photon_list property exists then load as a VolumeGrid code object
+        if (props.has_property("photon_list")) {
+            // Log(Info, "photon emitter reading from code object (VolumeGrid)");
+            // If filename has also been specified then ignore it
+            if (props.has_property("filename")) {
+                FileResolver *fs = Thread::thread()->file_resolver();
+                fs::path file_path = fs->resolve(props.string("filename"));
+                Log(Info, "The parameters 'filename' and 'photon_list' were both specified; ignoring 'filename'.");
+            }
 
-            target_x.push_back(a);
-            target_y.push_back(b);
-            target_z.push_back(c);
-            counter ++;
+            ref<Object> other = props.object("photon_list");
+            VolumeGrid *volume_grid = dynamic_cast<VolumeGrid *>(other.get());
+            float *ptr = volume_grid->data();
+            int count = ptr[0];
+            int counter = 0.;
+            std::vector<float> origin_x, origin_y, origin_z, target_x, target_y, target_z;
+            while (counter != count) {
+                float x = ptr[1+counter*6];
+                float y = ptr[2+counter*6];
+                float z = ptr[3+counter*6];
+
+                origin_x.push_back(x);
+                origin_y.push_back(y);
+                origin_z.push_back(z);
+                // Declare three float variables
+                float a = ptr[4+counter*6];
+                float b = ptr[5+counter*6];
+                float c = ptr[6+counter*6];
+
+                target_x.push_back(a);
+                target_y.push_back(b);
+                target_z.push_back(c);
+                counter ++;
+            }
+            // Load them each into separate Float variables
+            float_origin_x = dr::load<Float>(origin_x.data(), count);
+            float_origin_y = dr::load<Float>(origin_y.data(), count);
+            float_origin_z = dr::load<Float>(origin_z.data(), count);
+            float_target_x = dr::load<Float>(target_x.data(), count);
+            float_target_y = dr::load<Float>(target_y.data(), count);
+            float_target_z = dr::load<Float>(target_z.data(), count);
+        // Otherwise look for a filename property and load that
+        } else if (props.has_property("filename")) {
+            // Read the file
+            FileResolver *fs = Thread::thread()->file_resolver();
+            fs::path file_path = fs->resolve(props.string("filename"));
+            m_filename = file_path.filename().string();
+            ref<FileStream> binaryStream = new FileStream(file_path, FileStream::ERead);
+            binaryStream -> set_byte_order(Stream::ELittleEndian);
+
+            // The first line of the file shows the number of the photons
+            size_t count;
+            binaryStream->read(&count, sizeof(size_t));
+            // std::cout << "The number of photons is: " << count << std::endl;
+            size_t counter = 0.;
+            std::vector<float> origin_x, origin_y, origin_z, target_x, target_y, target_z;
+            while (counter != count) {
+                // Declare three float variables
+                float x,y,z;
+                binaryStream->read(&x, sizeof(float));
+                binaryStream->read(&y, sizeof(float));
+                binaryStream->read(&z, sizeof(float));
+                origin_x.push_back(x);
+                origin_y.push_back(y);
+                origin_z.push_back(z);
+                // Declare three float variables
+                float a,b,c;
+                binaryStream->read(&a, sizeof(float));
+                binaryStream->read(&b, sizeof(float));
+                binaryStream->read(&c, sizeof(float));
+                target_x.push_back(a);
+                target_y.push_back(b);
+                target_z.push_back(c);
+                counter ++;
+            }
+            binaryStream->close();
+            // Load them each into separate Float variables
+            float_origin_x = dr::load<Float>(origin_x.data(), count);
+            float_origin_y = dr::load<Float>(origin_y.data(), count);
+            float_origin_z = dr::load<Float>(origin_z.data(), count);
+            float_target_x = dr::load<Float>(target_x.data(), count);
+            float_target_y = dr::load<Float>(target_y.data(), count);
+            float_target_z = dr::load<Float>(target_z.data(), count);
+        } else {
+            Throw("A photon emitter requires one of 'photon_list' (VolumeGrid code object) or 'filename' (binary file) to be specified.");
         }
 
-        // // Read the file
-        // FileResolver *fs = Thread::thread()->file_resolver();
-        // fs::path file_path = fs->resolve(props.string("filename"));
-        // m_filename = file_path.filename().string();
-        // ref<FileStream> binaryStream = new FileStream(file_path, FileStream::ERead);
-        // binaryStream -> set_byte_order(Stream::ELittleEndian);
-
-        // // The first line of the file shows the number of the photons
-        // size_t count;
-        // binaryStream->read(&count, sizeof(size_t));
-        // // std::cout << "The number of photons is: " << count << std::endl;
-        // size_t counter = 0.;
-        // // Create vectors to store the coodrinations
-        // std::vector<float> origin_x, origin_y, origin_z, target_x, target_y, target_z;
-        // while (counter != count) {
-        //     // Declare three float variables
-        //     float x,y,z;
-        //     binaryStream->read(&x, sizeof(float));
-        //     binaryStream->read(&y, sizeof(float));
-        //     binaryStream->read(&z, sizeof(float));
-        //     origin_x.push_back(x);
-        //     origin_y.push_back(y);
-        //     origin_z.push_back(z);
-        //     // Declare three float variables
-        //     float a,b,c;
-        //     binaryStream->read(&a, sizeof(float));
-        //     binaryStream->read(&b, sizeof(float));
-        //     binaryStream->read(&c, sizeof(float));
-        //     target_x.push_back(a);
-        //     target_y.push_back(b);
-        //     target_z.push_back(c);
-        //     counter ++;
-        // }
-        // binaryStream->close();
-        // Load them each into separate Float variables
-        Float float_origin_x = dr::load<Float>(origin_x.data(), count);
-        Float float_origin_y = dr::load<Float>(origin_y.data(), count);
-        Float float_origin_z = dr::load<Float>(origin_z.data(), count);
-        Float float_target_x = dr::load<Float>(target_x.data(), count);
-        Float float_target_y = dr::load<Float>(target_y.data(), count);
-        Float float_target_z = dr::load<Float>(target_z.data(), count);
         // Create two Point3f and one Vector3f for origins, targets and ups from these Float variables
         Point3f origin(float_origin_x, float_origin_y, float_origin_z);
         Point3f target(float_target_x, float_target_y, float_target_z);

--- a/src/emitters/photon_emitter.cpp
+++ b/src/emitters/photon_emitter.cpp
@@ -194,6 +194,8 @@ public:
             Throw("The parameter 'intensity' cannot be spatially varying (e.g. bitmap type)!");
         // dr::set_attr(this, "flags", m_flags);
         // degree to radiance: degree * pi / 180
+        // TODO: do these need to be parameters for this emitter, or are they
+        ///      covered by the information in the photon list that's been loaded in?
         m_cutoff_angle = dr::deg_to_rad(0.01f);
         m_beam_width   = dr::deg_to_rad(0.01f*3.0f / 4.0f);
         // if the m_cutoff_angle is equal to m_beam_width, the denominator will be 0, it's impossible!
@@ -213,6 +215,7 @@ public:
                                           Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::EndpointSampleRay, active);
         // 1. Sample directional component
+        // TODO: again this is a single direction? Should it be allowed to be multiple?
         ScalarVector3f local_dir =  ScalarVector3f(0.f, 0.f, 1.f);
         Float pdf_dir = 445029;
         // Uniformly sample the light rays
@@ -230,6 +233,7 @@ public:
         // generate a set of random wavelengths and the corresponding spectral weight
         auto [wavelengths, spec_weight] =
             sample_wavelengths(si, wavelength_sample, active);
+        // TODO: calculate falloff using falloff_curve ?
         Float falloff = 1.0f;
         Ray3f result = Ray3f(si.p, new_dir, time, wavelengths);
         return {result, depolarizer<Spectrum>(spec_weight * falloff / pdf_dir)};
@@ -311,6 +315,7 @@ public:
         oss << "PhotonEmitter[" << std::endl
             << "  to_world = " << string::indent(m_to_world) << "," << std::endl
             << "  intensity = " << m_intensity << "," << std::endl
+            // TODO: cutoff_angle isn't a parameter, so should it be here?
             << "  cutoff_angle = " << m_cutoff_angle << "," << std::endl
             << "  beam_width = " << m_beam_width << "," << std::endl
             << "  medium = " << (m_medium ? string::indent(m_medium) : "")

--- a/src/emitters/photon_emitter.cpp
+++ b/src/emitters/photon_emitter.cpp
@@ -18,9 +18,69 @@
 #include <drjit/texture.h>
 #include <vector>
 
-// std::cout << "!!!" << std::endl;
-
 NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _emitter-photon:
+
+Photon light source (:monosp:`photon_emitter`)
+----------------------------------------------
+TODO: rename this to "photon" rather than "photon_emitter"
+
+.. pluginparameters::
+
+ * - intensity
+   - |spectrum|
+   - Specifies the maximum radiant intensity at the center in units of power per unit steradian. (Default: 1).
+     This cannot be spatially varying (e.g. have bitmap as type).
+   - |exposed|, |differentiable|
+
+ * - filename
+   - |string|
+   - Specifies a binary file from which photon ray locations are loaded in the form origin x,y,z, target x,y,z
+
+ * - photon_list
+   - |VolumeGrid|
+   - Specifies a mitsuba VolumeGrid object from which photon ray locations can be loaded in the form origin x,y,z, target x,y,z
+
+TODO: Does to_world work for this emitter?  It seems to have been turned off in some functions but not others.
+ * - to_world
+   - |transform|
+   - Specifies an optional emitter-to-world transformation.  (Default: none, i.e. emitter space = world space)
+   - |exposed|
+
+This plugin provides a photon light source. The coordinates of rays associated with photons can be loaded
+in from either a binary file (see tests for an example) using the 'filename' parameter in a dict or XML, or 
+optionally from a VolumeGrid code object when using a scene description (Python) dictionary.
+
+.. tabs::
+    .. code-tab:: xml
+        :name: photon-emitter
+
+        <emitter type="photon_emitter">
+            <rgb name="intensity" value="1.0"/>
+            <string name="filename" value="bintxt/photon_geometry.bin"/>
+        </emitter>
+
+    .. code-tab:: python
+
+        'type': 'photon_emitter',
+        'photon_list': photon_list,
+        'intensity': intensity,
+
+The intensity is a fixed value.
+
+TODO: Add some figures showing what's happening here?
+.. subfigstart::
+.. subfigure:: ../../resources/data/docs/images/render/emitter_spot_no_texture.jpg
+   :caption: Two spot lights with different colors and no texture specified.
+.. subfigure:: ../../resources/data/docs/images/render/emitter_spot_texture.jpg
+   :caption: A spot light with a texture specified.
+.. subfigend::
+   :label: fig-spot-light
+
+ */
 
 template <typename Float, typename Spectrum>
 class PhotonEmitter final : public Emitter<Float, Spectrum> {

--- a/src/emitters/tests/test_photon.py
+++ b/src/emitters/tests/test_photon.py
@@ -1,0 +1,170 @@
+import pytest
+import numpy as np
+import drjit as dr
+import mitsuba as mi
+
+
+spectrum_dicts = {
+    'd65': { 'type' : 'd65' },
+    'regular': {
+        'type' : 'regular',
+        'wavelength_min' : 500.0,
+        'wavelength_max' : 600.0,
+        'values' : "1, 2",
+    }
+}
+
+lookat_transforms = [
+    mi.scalar_rgb.ScalarTransform4f().look_at([0, 1, 0], [0, 0, 0], [1, 0, 0]),
+    mi.scalar_rgb.ScalarTransform4f().look_at([0, 0, 1], [0, 0, 0], [0, -1, 0])
+]
+
+# Set up some basic photon data
+emitter_data = [2, -8.6815998e-02, 1.0280000e+03, 1.0275000e+02, -1.3769200e-01,  1.0289886e+03,  1.0284847e+02, 
+                -8.6815998e-02, 1.0280000e+03,  1.0275000e+02, -3.8943999e-02,  1.0289916e+03, 1.0286631e+02]
+photon_data = np.zeros((1, 1, len(emitter_data)), dtype=np.float32)
+photon_data[0, 0, :] = emitter_data
+
+
+def create_emitter_and_spectrum(lookat, s_key='d65'):
+    spectrum = mi.load_dict(spectrum_dicts[s_key])
+    expanded = spectrum.expand()
+    if len(expanded) == 1:
+        spectrum = expanded[0]
+
+    photon_list = mi.VolumeGrid(photon_data)
+    emitter = mi.load_dict({
+        'type' : 'photon_emitter',
+        'photon_list' : photon_list,
+        # 'cutoff_angle' : cutoff_angle,
+        'to_world' : lookat,
+        'intensity' : spectrum
+    })
+
+    return emitter, spectrum
+
+
+@pytest.mark.parametrize("spectrum_key", spectrum_dicts.keys())
+@pytest.mark.parametrize("it_pos", [[2.0, 0.5, 0.0], [1.0, 0.5, -5.0]])
+@pytest.mark.parametrize("wavelength_sample", [0.7])
+# @pytest.mark.parametrize("cutoff_angle", [20, 80])
+@pytest.mark.parametrize("lookat", lookat_transforms)
+def test_sample_direction(variant_scalar_spectral, spectrum_key, it_pos, wavelength_sample, lookat):
+    """ Check the correctness of the sample_direction() method """
+
+    # Test a fixed cutoff angle?
+    cutoff_angle = 20
+    cutoff_angle_rad = cutoff_angle / 180 * dr.pi
+    beam_width_rad = cutoff_angle_rad * 0.75
+    inv_transition_width = 1 / (cutoff_angle_rad - beam_width_rad)
+    emitter, spectrum = create_emitter_and_spectrum(lookat, spectrum_key)
+    eval_t = 0.3
+    # TODO: work out how to test the transforms used in the photon emitter here
+    trafo = mi.Transform4f(emitter.world_transform())
+
+    # Create a surface iteration
+    it = mi.SurfaceInteraction3f()
+    it.wavelengths = [0, 0, 0, 0]
+    it.p = it_pos
+    it.time = eval_t
+
+    # Sample a wavelength from spectrum
+    wav, spec = spectrum.sample_spectrum(it, mi.sample_shifted(wavelength_sample))
+    it.wavelengths = wav
+
+    # Direction from the position to the point emitter
+    d = mi.Vector3f(-it.p + lookat.translation())
+    dist = dr.norm(d)
+    d /= dist
+
+    # Calculate angle between lookat direction and ray direction
+    angle = dr.acos((trafo.inverse() @ (-d))[2])
+    angle = dr.select(dr.abs(angle - beam_width_rad)
+                      < 1e-3, beam_width_rad, angle)
+    angle = dr.select(dr.abs(angle - cutoff_angle_rad)
+                      < 1e-3, cutoff_angle_rad, angle)
+
+    # Sample a direction from the emitter
+    ds, res = emitter.sample_direction(it, [0, 0])
+
+    # Evaluate the spectrum
+    spec = spectrum.eval(it)
+    spec = dr.select(angle <= beam_width_rad, spec, spec *
+                     ((cutoff_angle_rad - angle) * inv_transition_width))
+    spec = dr.select(angle <= cutoff_angle_rad, spec, 0)
+
+    assert ds.time == it.time
+    assert ds.pdf == 1.0
+    assert ds.delta
+    # assert dr.allclose(ds.d, d)
+    # assert dr.allclose(res, spec / (dist**2))
+
+
+@pytest.mark.parametrize("spectrum_key", spectrum_dicts.keys())
+@pytest.mark.parametrize("wavelength_sample", [0.7])
+@pytest.mark.parametrize("pos_sample", [[0.4, 0.5], [0.1, 0.4]])
+# @pytest.mark.parametrize("cutoff_angle", [20, 80])
+@pytest.mark.parametrize("lookat", lookat_transforms)
+def test_sample_ray(variants_vec_spectral, spectrum_key, wavelength_sample, pos_sample, lookat):
+    # Check the correctness of the sample_ray() method
+
+    # Fixed cutoff angle
+    cutoff_angle = 20
+    cutoff_angle_rad = cutoff_angle / 180 * dr.pi
+    cos_cutoff_angle_rad = dr.cos(cutoff_angle_rad)
+    beam_width_rad = cutoff_angle_rad * 0.75
+    inv_transition_width = 1 / (cutoff_angle_rad - beam_width_rad)
+    emitter, spectrum = create_emitter_and_spectrum(
+        lookat, spectrum_key)
+    eval_t = 0.3
+    # TODO: work out how to test the transforms used in the photon emitter here
+    trafo = mi.Transform4f(emitter.world_transform())
+
+    # Sample a local direction and calculate local angle
+    dir_sample = pos_sample  # not being used anyway
+    # local_dir = mi.warp.square_to_uniform_cone(pos_sample, cos_cutoff_angle_rad)
+    local_dir = mi.ScalarVector3f(0., 0., 1.)     
+    angle = dr.acos(local_dir[2])
+    angle = dr.select(dr.abs(angle - beam_width_rad)
+                      < 1e-3, beam_width_rad, angle)
+    angle = dr.select(dr.abs(angle - cutoff_angle_rad)
+                      < 1e-3, cutoff_angle_rad, angle)
+
+    # Sample a ray (position, direction, wavelengths) from the emitter
+    ray, res = emitter.sample_ray(
+        eval_t, wavelength_sample, pos_sample, dir_sample)
+
+    # Sample wavelengths on the spectrum
+    it = dr.zeros(mi.SurfaceInteraction3f)
+    wav, spec = spectrum.sample_spectrum(it, mi.sample_shifted(wavelength_sample))
+    it.wavelengths = wav
+    spec = spec * dr.select(angle <= beam_width_rad,
+                            1,
+                            ((cutoff_angle_rad - angle) * inv_transition_width))
+    spec = dr.select(angle <= cutoff_angle_rad, spec, 0)
+
+    # assert dr.allclose(
+    #     res, spec / mi.warp.square_to_uniform_cone_pdf(trafo.inverse() @ ray.d, cos_cutoff_angle_rad))
+    pdf_dir = 445029
+    assert dr.allclose(res, spec / pdf_dir)
+    assert dr.allclose(ray.time, eval_t)
+    assert dr.all(local_dir.z >= cos_cutoff_angle_rad)
+    assert dr.allclose(ray.wavelengths, wav)
+    # TODO: work out how to test the transforms used in the photon emitter here
+    # assert dr.allclose(ray.d, trafo @ local_dir)
+    # assert dr.allclose(ray.o, lookat.translation())
+
+
+@pytest.mark.parametrize("spectrum_key", spectrum_dicts.keys())
+# @pytest.mark.parametrize("cutoff_angle", [20, 60])
+@pytest.mark.parametrize("lookat", lookat_transforms)
+def test_eval(variants_vec_spectral, spectrum_key, lookat):
+    # Check the correctness of the eval() method
+
+    emitter, spectrum = create_emitter_and_spectrum(
+        lookat, spectrum_key)
+
+    # Check that incident direction in the illuminated direction is zero (because hitting a delta light is impossible)
+    it = dr.zeros(mi.SurfaceInteraction3f, 3)
+    it.wi = [0, 1, 0]
+    assert dr.allclose(emitter.eval(it), 0.)


### PR DESCRIPTION
Resolves #13

Making it possible to load photons either from a dict (via a VolumeGrid code object, or from a binary file) or XML (from a binary file).

Added a simple test script  to the SingleEmitter directory which can be used for any of the three cases.  (Note that it's not possible to load a code object from an XML file).

Leaving in draft form for now while I consider whether there are any improvements or simplifications to the code as it stands.

